### PR TITLE
Update install-hdfs.sh

### DIFF
--- a/packer/provisioners/install-hdfs.sh
+++ b/packer/provisioners/install-hdfs.sh
@@ -13,7 +13,7 @@ sudo sh -c 'echo "net.ipv6.conf.default.disable_ipv6 = 1" >> /etc/sysctl.conf'
 sudo sh -c 'echo "net.ipv6.conf.lo.disable_ipv6 = 1" >> /etc/sysctl.conf'
 
 echo "Fetching Hadoop..."
-HADOOP_DOWNLOAD_URL=http://apache.mirrors.spacedump.net/hadoop/common/hadoop-2.6.0/hadoop-2.6.0.tar.gz
+HADOOP_DOWNLOAD_URL=http://www-us.apache.org/dist/hadoop/common/hadoop-2.6.5/hadoop-2.6.5.tar.gz
 HADOOP_TGZ=${HADOOP_DOWNLOAD_URL##*/}
 HADOOP_PACKAGE_NAME=${HADOOP_TGZ%.tar.gz}
 wget -q $HADOOP_DOWNLOAD_URL -O /tmp/$HADOOP_TGZ


### PR DESCRIPTION
Changed hadoop download mirror link. This version 2.6.5 worked for me and 2.6.0 is not available anyway.